### PR TITLE
Admin cleanup

### DIFF
--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -13,12 +13,6 @@ class ProvidersController < ApplicationController
     @provider = Provider.find_by(id: params[:id])
   end
 
-  def edit
-  end
-
-  def update
-  end
-
   private
   def provider_params
     params.require(:provider).permit(:name, :city)

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,11 +8,11 @@ class Ability
     if user.role == "superadmin"
       can :access, :rails_admin
       can :dashboard
-      can :manage, :all
+      can :manage, [Provider, Insurer, User]
     elsif user.role == "admin"
       can :access, :rails_admin
       can :dashboard
-      can :manage, [Provider, Insurer, ProviderInsurer]
+      can :manage, [Provider, Insurer]
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -8,7 +8,8 @@ class Ability
     if user.role == "superadmin"
       can :access, :rails_admin
       can :dashboard
-      can :manage, [Provider, Insurer, User]
+      can :manage, [Provider, Insurer]
+      can [:read, :update], [User]
     elsif user.role == "admin"
       can :access, :rails_admin
       can :dashboard

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,4 +1,6 @@
 %h2 Sign up
+%p Note that an account is only necessary for administrators, and grants no additional privileges. Once you create your account, however, the QuHac team can grant you access to administrative tools.
+
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = devise_error_messages!
   .field

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,7 +1,4 @@
 RailsAdmin.config do |config|
-
-  ### Popular gems integration
-
   ## == Devise ==
   config.authenticate_with do
     warden.authenticate! scope: :user
@@ -10,12 +7,6 @@ RailsAdmin.config do |config|
 
   ## == Cancan ==
   config.authorize_with :cancan
-
-  ## == Pundit ==
-  # config.authorize_with :pundit
-
-  ## == PaperTrail ==
-  # config.audit_with :paper_trail, 'User', 'PaperTrail::Version' # PaperTrail >= 3.0.0
 
   ### More at https://github.com/sferik/rails_admin/wiki/Base-configuration
 
@@ -29,9 +20,7 @@ RailsAdmin.config do |config|
     edit
     delete
     show_in_app
-
-    ## With an audit adapter, you can add:
-    # history_index
-    # history_show
   end
+
+  config.excluded_models = ["ProviderInsurer"]
 end

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -23,4 +23,14 @@ RailsAdmin.config do |config|
   end
 
   config.excluded_models = ["ProviderInsurer"]
+
+  config.model 'User' do
+    include_fields :email, :role
+    configure :email do
+      read_only true
+    end
+    configure :role do
+      help "Set to 'admin' to permit them to update provider and insurer data. Set to 'superadmin' to permit them to make changes to user's roles. Set to anything else to prevent them from accessing the admin dashboard."
+    end
+  end
 end

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -42,42 +42,4 @@ RSpec.describe ProvidersController, type: :controller do
       expect(assigns(:provider)).to eq(@pro1)
     end
   end
-
-  describe "access" do
-    before do
-      @admin = User.create(email: "admin1@example.com", password: "password", password_confirmation: "password", role: "admin")
-      @superadmin = User.create(email: "superadmin1@example.com", password: "password", password_confirmation: "password", role: "superadmin")
-      @user = User.create(email: "user1@example.com", password: "password", password_confirmation: "password", role: "user")
-    end
-
-    it "permits users to read Providers" do
-      sign_in @user
-      get :index
-
-      expect(response.code).to eq('200')
-    end
-
-    it "does not allow users to manage Providers" do
-      sign_in @user
-      put :update, id: @pro1.id, name: "Dr. Ewok"
-
-      expect(response.code).to eq('302')
-    end
-
-    it "permits admins to manage Providers" do
-      sign_in @admin
-
-      put :update, id: @pro1.id, name: "Dr. Ewok"
-
-      expect(response.code).to eq('200')
-    end
-
-    it "permits superadmins to manage Providers" do
-      sign_in @superadmin
-
-      put :update, id: @pro1.id, name: "Dr. Ewok"
-
-      expect(response.code).to eq('200')
-    end
-  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,5 +1,49 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'abilities' do
+    subject(:ability) { Ability.new(user) }
+    let(:user) { nil }
+
+    context 'user' do
+      let(:user) { User.create(role: "user", email: "user@example.com", password: "password", password_confirmation: "password")}
+      it{ should_not be_able_to(:manage, Provider.new) }
+      it{ should_not be_able_to(:manage, Insurer.new) }
+      it{ should_not be_able_to(:manage, ProviderInsurer.new) }
+      it{ should_not be_able_to(:manage, User.new) }
+      it{ should_not be_able_to(:access, :rails_admin) }
+    end
+
+    context 'admin' do
+      let(:user) { User.create(role: "admin", email: "admin@example.com", password: "password", password_confirmation: "password")}
+
+      it{ should be_able_to(:manage, Provider.new) }
+      it{ should be_able_to(:manage, Insurer.new) }
+      it{ should_not be_able_to(:manage, ProviderInsurer.new) }
+      it{ should_not be_able_to(:manage, User.new) }
+      it{ should_not be_able_to(:update, User.new) }
+      it{ should be_able_to(:access, :rails_admin) }
+    end
+
+    context 'superadmin' do
+      let(:user) { User.create(role: "superadmin", email: "superadmin@example.com", password: "password", password_confirmation: "password")}
+
+      it{ should be_able_to(:manage, Provider.new) }
+      it{ should be_able_to(:manage, Insurer.new) }
+      it{ should_not be_able_to(:manage, ProviderInsurer.new) }
+      it{ should_not be_able_to(:manage, User.new) }
+      it{ should be_able_to(:update, User.new) }
+      it{ should be_able_to(:access, :rails_admin) }
+    end
+
+    context 'rando' do
+      let(:user) { User.create(role: "donkey", email: "rando@example.com", password: "password", password_confirmation: "password")}
+      it{ should_not be_able_to(:manage, Provider.new) }
+      it{ should_not be_able_to(:manage, Insurer.new) }
+      it{ should_not be_able_to(:manage, ProviderInsurer.new) }
+      it{ should_not be_able_to(:manage, User.new) }
+      it{ should_not be_able_to(:access, :rails_admin) }
+    end
+  end
+
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -9,6 +9,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'cancan/matchers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
- removes ProviderInsurers from Admin Dashboard
- adds helpful text to sign up page telling user it won't get them anything 
- removes SuperAdmins' ability to view anything about users except role and email, can only edit role
- adds helpful text to form about role
- removes SuperAdmins' ability to create or destroy users 
- add tests for user abilities, using this guide: https://github.com/CanCanCommunity/cancancan/wiki/Testing-Abilities
