### PR TITLE
Chores, mostly about quick search form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,9 +23,9 @@ gem 'figaro'
 group :test do
   gem 'simplecov', require: false
   gem 'capybara'
+  gem 'rspec-rails', '~> 3.0'
 end
 
 group :development, :test do
-  gem 'rspec-rails', '~> 3.0'
   gem 'pry'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,3 @@ DEPENDENCIES
   simplecov
   turbolinks
   uglifier (>= 1.3.0)
-
-BUNDLED WITH
-   1.11.2

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,9 @@
 require File.expand_path('../config/application', __FILE__)
 
 Rails.application.load_tasks
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+  task :default => [:spec]
+rescue LoadError
+end

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -4,6 +4,7 @@ class ProvidersController < ApplicationController
   def index
     if params[:search]
       @providers = Provider.search(params[:search])
+      @showing_results = true
     else
       @providers = Provider.all
     end

--- a/app/controllers/providers_controller.rb
+++ b/app/controllers/providers_controller.rb
@@ -4,6 +4,8 @@ class ProvidersController < ApplicationController
   def index
     if params[:search]
       @providers = Provider.search(params[:search])
+      @clinics = Clinic.search(params[:search])
+      @providers += Provider.where(clinic: @clinics)
       @showing_results = true
     else
       @providers = Provider.all

--- a/app/models/clinic.rb
+++ b/app/models/clinic.rb
@@ -2,4 +2,9 @@ class Clinic < ActiveRecord::Base
   validates :street_address, :phone, :city, :zip, presence: true
 
   has_many :providers
+
+  def self.search(search)
+    search_length = search.split.length
+    where([(['lower(name) LIKE lower(?)'] * search_length).join(' AND ')] + search.split.map { |search| "%#{search}%" })
+  end
 end

--- a/app/models/provider.rb
+++ b/app/models/provider.rb
@@ -11,7 +11,9 @@ class Provider < ActiveRecord::Base
 
   def self.search(search)
     search_length = search.split.length
-    where([(['lower(name) LIKE lower(?)'] * search_length).join(' AND ')] + search.split.map { |search| "%#{search}%" })
+    where([(['lower(name) LIKE lower(?)'] * search_length).join(' AND ')] + search.split.map { |search| "%#{search}%" }) +
+    where([(['lower(type) LIKE lower(?)'] * search_length).join(' AND ')] + search.split.map { |search| "%#{search}%" }) +
+    where([(['lower(specialization) LIKE lower(?)'] * search_length).join(' AND ')] + search.split.map { |search| "%#{search}%" })
   end
 
   def accepts_medicaid

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -54,4 +54,3 @@
             .col-xs-4.col-xs-offset-4.col-sm-2.col-sm-offset-5.text-center
               = link_to root_path do
                 = image_tag("gchp-aptby-black.jpg")
-

--- a/app/views/providers/_quick_search_form.html.haml
+++ b/app/views/providers/_quick_search_form.html.haml
@@ -1,0 +1,13 @@
+.quick-search.col-xs-12.col-sm-5
+  %h2.text-center Quick Search
+  .quick-row-1
+    = form_tag "/providers", method: "get" do
+      = label_tag "search", "Search for Providers by Name, Type, or Population Specialization"
+      = text_field_tag :search, params[:search], placeholder: "acupuncturist"
+      = submit_tag "Search", name: nil, :class => "base-submit"
+  .quick-row-2
+    - unless @providers
+      = link_to providers_path do
+        .btn.btn-link.grey-button Browse All Providers
+    = link_to advanced_search_path do
+      .btn.btn-link.grey-button Advanced Search

--- a/app/views/providers/index.html.haml
+++ b/app/views/providers/index.html.haml
@@ -7,6 +7,10 @@
 
 .row
   .col-xs-10.col-xs-offset-1
+    = render 'providers/quick_search_form'
+
+.row
+  .col-xs-10.col-xs-offset-1
     - @providers.each do |provider|
       .row.card
         .col-xs-2

--- a/app/views/providers/index.html.haml
+++ b/app/views/providers/index.html.haml
@@ -1,6 +1,9 @@
 .row
   .col-xs-12.results-head
-    %h1.col-xs-10.col-xs-offset-1 Provider Search Results
+    - if @showing_results
+      %h1.col-xs-10.col-xs-offset-1 Provider Search Results
+    - else
+      %h1.col-xs-10.col-xs-offset-1 Providers
 
 .row
   .col-xs-10.col-xs-offset-1
@@ -36,7 +39,8 @@
                   Insurance accepted:
                   %p= provider.insurers.map { |ins| ins.name } .join(", ")
 
-.row
-  .col-xs-6.col-xs-offset-3.col-sm-4.col-sm-offset-4
-    = link_to providers_path do
-      %button.base-submit.clr-search.center-block Clear Search
+- if @showing_results
+  .row
+    .col-xs-6.col-xs-offset-3.col-sm-4.col-sm-offset-4
+      = link_to providers_path do
+        %button.base-submit.clr-search.center-block Clear Search

--- a/app/views/static_pages/about.haml
+++ b/app/views/static_pages/about.haml
@@ -1,17 +1,6 @@
 .row
   .col-xs-12
-    .quick-search.col-xs-12.col-sm-5
-      %h2.text-center Quick Search
-      .quick-row-1
-        = form_tag "/providers", method: "get" do
-          = label_tag "Search for Providers"
-          = text_field_tag :search, params[:search], placeholder:"sparkle"
-          = submit_tag "Search", name: nil, :class => "base-submit"
-      .quick-row-2
-        = link_to providers_path do
-          .btn.btn-link.grey-button Browse All Providers
-        = link_to advanced_search_path do
-          .btn.btn-link.grey-button Advanced Search
+    = render 'providers/quick_search_form'
 
     .about.col-xs-12.col-sm-7.text-center
       %h2 About

--- a/spec/controllers/providers_controller_spec.rb
+++ b/spec/controllers/providers_controller_spec.rb
@@ -2,12 +2,46 @@ require 'rails_helper'
 
 RSpec.describe ProvidersController, type: :controller do
   before do
-    clinic1 = Clinic.create(street_address: "123 Pine St", city: "Seattle", zip: "98122", phone: "206-206-1206")
-    clinic2 = Clinic.create(street_address: "123 Spruce St", city: "Woodinville", zip: "98199", phone: "206-206-1206")
-    @pro1 = Provider.create(name: "Dr. McCoy", clinic_id: clinic2.id)
-    @pro2 = Provider.create(name: "Dr. Torres", clinic_id: clinic1.id)
-    @monkey_provider = Provider.create(name: "Dr. Monkey", clinic_id: clinic1.id)
-    @lion_provider = Provider.create(name: "Dr. Lion", clinic_id: clinic2.id)
+    clinic1 = Clinic.create(
+      name: "Jungle Clinic",
+      street_address: "123 Pine St",
+      city: "Seattle",
+      zip: "98122",
+      phone: "206-206-1206"
+    )
+    @clinic2 = Clinic.create(
+      name: "Savannah Clinic",
+      street_address: "123 Spruce St",
+      city: "Woodinville",
+      zip: "98199",
+      phone: "206-206-1206"
+    )
+
+    @pro2 = Provider.create(
+      name: "Dr. Torres",
+      clinic_id: clinic1.id,
+      specialization: "diabetics, squids",
+      type: "phrenologist"
+    )
+    @monkey_provider = Provider.create(
+      name: "Dr. Monkey",
+      clinic_id: clinic1.id,
+      specialization: "trans-men, athletes",
+      type: "dermatologist"
+    )
+
+    @pro1 = Provider.create(
+      name: "Dr. McCoy",
+      clinic_id: @clinic2.id,
+      specialization: "trans-men, diabetics, athletes",
+      type: ""
+    )
+    @lion_provider = Provider.create(
+      name: "Dr. Lion",
+      clinic_id: @clinic2.id,
+      specialization: "",
+      type: "acupuncturist"
+    )
   end
 
 
@@ -23,18 +57,33 @@ RSpec.describe ProvidersController, type: :controller do
     end
 
 
-    it "returns providers that match query" do
+    it "returns providers whose name matches query" do
       get :index, search: "monkey"
 
       expect(assigns(:providers)).to eq([@monkey_provider])
     end
 
-    it "returns providers that match query" do
-      pending "search does not hit city right now, as it's delegated to clinic"
-      get :index, search: "Seattle"
+    it "returns providers whose type matches query" do
+      get :index, search: "phrenologist"
 
+      expect(assigns(:providers)).to eq([@pro2])
+    end
+
+    it "returns providers whose specialization matches query" do
+      get :index, search: "trans-men"
+
+      expect(assigns(:providers).length).to eq(2)
+      expect(assigns(:providers)).to include(@monkey_provider)
+      expect(assigns(:providers)).to include(@pro1)
+    end
+
+    it "returns providers whose clinic name matches query" do
+      get :index, search: "Savannah"
+
+      expect(assigns(:providers).length).to eq(2)
+      expect(assigns(:clinics)).to eq([@clinic2])
       expect(assigns(:providers)).to include(@lion_provider)
-      expect(assigns(:providers)).to include(@pro2)
+      expect(assigns(:providers)).to include(@pro1)
     end
   end
 


### PR DESCRIPTION
- group gems sensibly
- show search related stuff (like "clear search") on providers#index only when it's displaying search results
- add a default rake task that runs specs
- move quick search form to a partial, make it user friendlier, include it in providers#index, make it search the desired attrs and add tests for that
